### PR TITLE
Feature: 'drop' event emits the index at which the item was dropped. #52

### DIFF
--- a/src/services/drake-store.service.ts
+++ b/src/services/drake-store.service.ts
@@ -118,6 +118,7 @@ export class DrakeStoreService {
       if (this.droppableMap.has(target)) {
         const targetComponent = this.droppableMap.get(target);
         let dropElmModel = draggedItem;
+        let dropIndex = undefined;
 
         if (this.droppableMap.has(source)) {
           const sourceComponent = this.droppableMap.get(source);
@@ -125,7 +126,7 @@ export class DrakeStoreService {
           const sourceModel = sourceComponent.model;
           const targetModel = targetComponent.model;
 
-          const dropIndex = Array.prototype.indexOf.call(target.children, el);
+          dropIndex = Array.prototype.indexOf.call(target.children, el);
           const dragIndex = (sourceModel && draggedItem) ? sourceModel.indexOf(draggedItem) : -1;
 
           if (dropIndex > -1 && targetModel) {
@@ -156,7 +157,8 @@ export class DrakeStoreService {
           type: 'drop',
           el,
           source,
-          value: dropElmModel
+          value: dropElmModel,
+          dropIndex: dropIndex
         });
       }
     });


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
As described in issue #52, the drop event data doesn't contain the index at which an item was dropped and there is no way to find that out. In my case, I want to fire a Redux action and the payload should contain the dropped item and its position.


**What is the new behavior?**
The data of the 'drop' event contains a new 'dropIndex' field containing the index at which the item was dropped.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
