### PR TITLE
make the index available in the template for ngx-dnd-containter component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-* Fixed AOT issue
+* Feature: make the index available in the template for ngx-dnd-containter component
 
 --------------------
 
 ## 3.1.2 (2018-01-19)
-_(none)_
+* Fixed AOT issue
 
 ## 3.1.1 (2017-12-04)
 * Fix draging between containers

--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -440,10 +440,11 @@
             (out)="log($event)"
             (remove)="log($event)">
 
-            <ng-template let-model="model" let-template="template">
+            <ng-template let-model="model" let-template="template" let-index="index">
               <div [ngSwitch]="model.inputType">
                 <div *ngSwitchCase="'section'">
                    <ngx-section class="shadow" [sectionTitle]="model.name">
+                     index {{index}}
                      <ngx-dnd-container
                        dropZone="builder-target"
                        [model]="model.children"
@@ -455,10 +456,11 @@
                        (over)="log($event)"
                        (out)="log($event)"
                        (remove)="log($event)">
-                     </ngx-dnd-container>
+                      </ngx-dnd-container>
                    </ngx-section>
                 </div>
                 <div *ngSwitchDefault>
+                  index {{index}}
                   <ngx-input
                     [type]="model.inputType"
                     [hint]="model.name"

--- a/src/components/container/container.component.html
+++ b/src/components/container/container.component.html
@@ -7,7 +7,7 @@
   [removeOnSpill]="removeOnSpill"
   class='ngx-dnd-container'>
   <ng-container *ngIf="model">
-    <ng-container *ngFor="let item of model">
+    <ng-container *ngFor="let item of model; let i = index">
       <ngx-dnd-item
         ngxDraggable
         [model]="item"
@@ -16,7 +16,8 @@
         [copy]="copy"
         [moves]="moves"
         [removeOnSpill]="removeOnSpill"
-        [droppableItemClass]="droppableItemClass">
+        [droppableItemClass]="droppableItemClass"
+        [index]="i">
       </ngx-dnd-item>
     </ng-container>
   </ng-container>

--- a/src/components/item/item.component.ts
+++ b/src/components/item/item.component.ts
@@ -67,11 +67,20 @@ export class ItemComponent implements OnInit {
     this._copy = val;
   }
 
+  @Input()
+  set index(val: number) {
+    this._index = val;
+    if (this.data) {
+      this.data.index = val;
+    }
+  };
+
   _copy = false;
   _dropZone: any;
   _dropZones: any;
   _droppableItemClass: any;
   _removeOnSpill = false;
+  _index: number;
   data: any;
 
   get hasHandle(): boolean {
@@ -115,7 +124,8 @@ export class ItemComponent implements OnInit {
       model: this.model,
       type: this.type,
       dropZone: this.dropZone,
-      template: this.container.template
+      template: this.container.template,
+      index: this._index
     };
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
when using the ngx-dnd-container component the index of the items is not available


**What is the new behavior?**
via the template context the index of every item is available


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No