### PR TITLE
Add forRoot static method to use in app root module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Note: This project is under heavy construction. As such, the API may change dra
 To use ngx-dnd in your project install it via [npm](https://www.npmjs.com/package/@swimlane/ngx-dnd):
 
 * `npm i @swimlane/ngx-dnd @swimlane/dragula --save`
-* Add `NgxDnDModule` to your application module
+* Add `NgxDnDModule.forRoot()` to your application module
 * If using directives you will need to BYO styles or include `@swimlane/ngx-dnd/release/index.css`.
 
 ## Quick intro and examples

--- a/projects/swimlane/ngx-dnd/src/lib/ngx-dnd.module.ts
+++ b/projects/swimlane/ngx-dnd/src/lib/ngx-dnd.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { DraggableDirective } from './directives/ngx-draggable.directive';
@@ -15,6 +15,12 @@ const directives = [DraggableDirective, DroppableDirective, DragHandleDirective]
   imports: [CommonModule],
   declarations: [...components, ...directives],
   exports: [...components, ...directives],
-  providers: [DrakeStoreService]
 })
-export class NgxDnDModule {}
+export class NgxDnDModule {
+  public static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: NgxDnDModule,
+      providers: [DrakeStoreService]
+    }
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,7 +25,7 @@ import { NgxDnDModule } from '@swimlane/ngx-dnd';
     FormsModule,
     FlexLayoutModule,
     NgxUIModule,
-    NgxDnDModule
+    NgxDnDModule.forRoot()
   ],
   declarations: [AppComponent],
   bootstrap: [AppComponent]


### PR DESCRIPTION
This enables using this library within an app with multiple feature modules

BREAKING CHANGE:
The AppModule now have to import the module using the .forRoot() static method of the module.

Fixes #114 (see this issue for more information)