### PR TITLE
Resolve Angular Ivy deep link warning

### DIFF
--- a/projects/swimlane/ngx-dnd/src/lib/ngx-dnd.module.ts
+++ b/projects/swimlane/ngx-dnd/src/lib/ngx-dnd.module.ts
@@ -7,7 +7,7 @@ import { DragHandleDirective } from './directives/ngx-drag-handle.directive';
 import { ContainerComponent } from './components/container/container.component';
 import { ItemComponent } from './components/item/item.component';
 import { DrakeStoreService } from './services/drake-store.service';
-import { ModuleWithProviders } from '@angular/compiler/src/core';
+import { core } from '@angular/compiler';
 
 const components = [ContainerComponent, ItemComponent];
 const directives = [DraggableDirective, DroppableDirective, DragHandleDirective];
@@ -18,7 +18,7 @@ const directives = [DraggableDirective, DroppableDirective, DragHandleDirective]
   exports: [...components, ...directives]
 })
 export class NgxDnDModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(): core.ModuleWithProviders {
     return {
       ngModule: NgxDnDModule,
       providers: [DrakeStoreService]


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Warning during compilation with Angular Ivy:

```
Warning: Entry point '@swimlane/ngx-dnd' contains deep imports into '/Users/samuelms/Documents/GitHub/datamonkey-frontend/node_modules/@angular/compiler/src/core'. This is probably not a problem, but may cause the compilation of entry points to be out of order.
```

See #160.

**What is the new behavior?**

No warning during compilation.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

@Hypercubed Very minor change to imports to resolve a warning during Angular Ivy compilation.