### PR TITLE
release:13.0.0

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 22.22.3
+          node-version: 24.18.0
 
       - name: Enable Corepack
         run: corepack enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## HEAD (Unreleased)
 
+## 13.0.0 (2026-07-29)
+
+- Added support for Angular 22
+- Removed support for Angular 19 and 20
+- Pinned Node.js to 24.18.0
+
 ## 12.0.0 (2026-06-17)
 
 - Added support for Angular 21

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "browserslist": "4.28.2"
   },
   "volta": {
-    "node": "22.22.3",
+    "node": "24.18.0",
     "yarn": "4.9.2"
   },
   "packageManager": "yarn@4.9.2"

--- a/projects/swimlane/ngx-dnd/package.json
+++ b/projects/swimlane/ngx-dnd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swimlane/ngx-dnd",
   "description": "Drag and Drop for Angular2 and beyond!",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "peerDependencies": {
     "@angular/common": "^21.2.0 || ^22.0.0",
     "@angular/core": "^21.2.0 || ^22.0.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [x] Other... Please describe: Release of `@swimlane/ngx-dnd@13.0.0`

**What is the current behavior?** (You can also link to an open issue here)

Library is published as `12.0.0`. Workspace/CI still pin Node.js `22.22.3`. Angular 22 support landed on master but has not been released.

**What is the new behavior?**

- Bumps `@swimlane/ngx-dnd` from `12.0.0` to `13.0.0`
- Pins Node.js to `24.18.0` in Volta and GitHub Actions
- Updates `CHANGELOG.md` for the 13.0.0 release (Angular 22 support; drop Angular 19/20)

**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications:

Peer dependencies no longer include Angular 19 or 20. Consumers must use Angular `^21.2.0` or `^22.0.0`. Upgrade Angular before upgrading `@swimlane/ngx-dnd` to `13.0.0`.
